### PR TITLE
Simplify message around nsjail error

### DIFF
--- a/ui/build/sandbox_linux.go
+++ b/ui/build/sandbox_linux.go
@@ -90,10 +90,7 @@ func (c *Cmd) sandboxSupported() bool {
 			return
 		}
 
-		c.ctx.Println("Build sandboxing disabled due to nsjail error. This may become fatal in the future.")
-		c.ctx.Println("Please let us know why nsjail doesn't work in your environment at:")
-		c.ctx.Println("  https://groups.google.com/forum/#!forum/android-building")
-		c.ctx.Println("  https://issuetracker.google.com/issues/new?component=381517")
+		c.ctx.Println("Build sandboxing disabled due to nsjail error.")
 
 		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
 			c.ctx.Verboseln(line)


### PR DESCRIPTION
We have known problems (docker; distros w/o user namespaces) which mean that we won't be turning this into a fatal error anytime soon. Also remove the bug report link, it's not useful to continue getting the same reports.

Change-Id: I271871d68150417ac938f074d3730cad4518e327
Test: treehugger